### PR TITLE
Bump xmltodict to match HA version to prevent reinstall during startup

### DIFF
--- a/custom_components/hpprinter/manifest.json
+++ b/custom_components/hpprinter/manifest.json
@@ -4,6 +4,6 @@
     "documentation": "https://github.com/elad-bar/ha-hpprinter/blob/master/README.md",
     "dependencies": [],
     "codeowners": ["@elad-bar"],
-    "requirements": ["xmltodict==0.4"],
+    "requirements": ["xmltodict==0.12.0"],
     "config_flow": true
 }


### PR DESCRIPTION
xmltodict gets reinstalled on every HA startup due to conflicting versions