### PR TITLE
Fix log errors caused by BW printers #57

### DIFF
--- a/custom_components/hpprinter/managers/HPDeviceData.py
+++ b/custom_components/hpprinter/managers/HPDeviceData.py
@@ -431,7 +431,6 @@ class HPDeviceData:
 
     @staticmethod
     def clean_parameter(data_item, data_key, default_value=NOT_AVAILABLE):
-            result = default_value
         try:
             result = data_item.get(data_key, {})
         except AttributeError:

--- a/custom_components/hpprinter/managers/HPDeviceData.py
+++ b/custom_components/hpprinter/managers/HPDeviceData.py
@@ -431,10 +431,11 @@ class HPDeviceData:
 
     @staticmethod
     def clean_parameter(data_item, data_key, default_value=NOT_AVAILABLE):
-        if data_item is None:
             result = default_value
-        else:
+        try:
             result = data_item.get(data_key, {})
+        except AttributeError:
+            result = default_value
 
         if not isinstance(result, str):
             result = result.get("#text", 0)


### PR DESCRIPTION
This seems to have fixed #57 and still behaves correctly when `data_item is None`