### PR TITLE
fix readme printer xml api url return 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Look for "HP Printers Integration" and install
 
 - HP Printer supporting XML API
   to check printer's compatibility to the component try to get to the printer's XML API (replace placeholder with real IP / Hostname):
-  `http://{IP}//DevMgmt/ProductStatusDyn.xml`
+  `http://{IP}/DevMgmt/ProductStatusDyn.xml`
 
 #### Basic configuration
 


### PR DESCRIPTION
I was wondering why the given XML API URL is returning http 404. It's caused by the double slash after the IP/Hostname variable:

`http://{IP}//DevMgmt/ProductStatusDyn.xml`

Removed by this PR.
