### PR TITLE
fix: fix spanish translation

### DIFF
--- a/custom_components/hpprinter/translations/es.json
+++ b/custom_components/hpprinter/translations/es.json
@@ -1,10 +1,10 @@
 {
   "config": {
     "abort": {
-      "already_configured": "Integraci\u00f3n de la impresora HP ({nombre}) ya configurada"
+      "already_configured": "Integraci\u00f3n de la impresora HP ({name}) ya configurada"
     },
     "error": {
-      "error_400": "Detalles del servidor no v\u00e1lidos, intente acceso manualmente a `http: // {ip} // devmgmt/productStatusDyn.xml` (reemplace el marcador de posici\u00f3n con IP o nombre de host), en caso de que est\u00e9 accesible, informe el problema con los registros",
+      "error_400": "Detalles del servidor no v\u00e1lidos, intente acceso manualmente a `http://{IP}/devmgmt/productStatusDyn.xml` (reemplace el marcador de posici\u00f3n con IP o nombre de host), en caso de que est\u00e9 accesible, informe el problema con los registros",
       "error_404": "API sin apoyo"
     },
     "step": {
@@ -105,8 +105,8 @@
   },
   "options": {
     "error": {
-      "already_configured": "Integraci\u00f3n de la impresora HP ({nombre}) ya configurada",
-      "error_400": "Detalles del servidor no v\u00e1lidos, intente acceso manualmente a `http: // {ip} // devmgmt/productStatusDyn.xml` (reemplace el marcador de posici\u00f3n con IP o nombre de host), en caso de que est\u00e9 accesible, informe el problema con los registros",
+      "already_configured": "Integraci\u00f3n de la impresora HP ({name}) ya configurada",
+      "error_400": "Detalles del servidor no v\u00e1lidos, intente acceso manualmente a `http://{IP}/devmgmt/productStatusDyn.xml` (reemplace el marcador de posici\u00f3n con IP o nombre de host), en caso de que est\u00e9 accesible, informe el problema con los registros",
       "error_404": "API sin apoyo"
     },
     "step": {


### PR DESCRIPTION
fix spanish translation. home assistant errors:

Validation of translation placeholders for localized (es) string component.hpprinter.options.error.already_configured failed: ({'nombre'} != {'name'})
Validation of translation placeholders for localized (es) string component.hpprinter.options.error.error_400 failed: ({'ip'} != {'IP'})
Validation of translation placeholders for localized (es) string component.hpprinter.config.abort.already_configured failed: ({'nombre'} != {'name'})
Validation of translation placeholders for localized (es) string component.hpprinter.config.error.error_400 failed: ({'ip'} != {'IP'})