### PR TITLE
Fix for async_config_entry_first_refresh warning

### DIFF
--- a/custom_components/hpprinter/managers/ha_coordinator.py
+++ b/custom_components/hpprinter/managers/ha_coordinator.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import Event, callback
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -88,7 +89,10 @@ class HACoordinator(DataUpdateCoordinator):
 
         await self._api.initialize()
 
-        await self.async_config_entry_first_refresh()
+        if entry.state == ConfigEntryState.LOADED:
+            await self.async_refresh()
+        else:
+            await self.async_config_entry_first_refresh()
 
     def _load_signal_handlers(self):
         loop = self.hass.loop


### PR DESCRIPTION
Inspired by https://github.com/home-assistant/core/pull/128152/

Fixes #185 

Should be backwards compatible. Tested locally on HA 2024.11, works as expected.