### PR TITLE
Add support for "image drum" and "rechargeable toner" consumption types

### DIFF
--- a/custom_components/hpprinter/parameters/data_points.json
+++ b/custom_components/hpprinter/parameters/data_points.json
@@ -189,8 +189,7 @@
             "printhead",
             "tonercartridge",
             "inktank",
-            "rechargeabletoner",
-            "imagedrum"
+            "rechargeabletoner"
           ]
         }
       }

--- a/custom_components/hpprinter/parameters/data_points.json
+++ b/custom_components/hpprinter/parameters/data_points.json
@@ -62,9 +62,11 @@
         "device_class": "enum",
         "validationWarning": true,
         "options": [
+          "imagedrum",
           "ink",
           "inkcartridge",
           "printhead",
+          "rechargeabletoner",
           "toner",
           "tonercartridge",
           "inktank"
@@ -187,7 +189,7 @@
             "printhead",
             "tonercartridge",
             "inktank",
-            "rechargeableToner",
+            "rechargeabletoner",
             "imagedrum"
           ]
         }

--- a/custom_components/hpprinter/parameters/data_points.json
+++ b/custom_components/hpprinter/parameters/data_points.json
@@ -186,7 +186,9 @@
             "inkcartridge",
             "printhead",
             "tonercartridge",
-            "inktank"
+            "inktank",
+            "rechargeabletoner",
+            "imagedrum"
           ]
         }
       }

--- a/custom_components/hpprinter/parameters/data_points.json
+++ b/custom_components/hpprinter/parameters/data_points.json
@@ -187,7 +187,7 @@
             "printhead",
             "tonercartridge",
             "inktank",
-            "rechargeabletoner",
+            "rechargeableToner",
             "imagedrum"
           ]
         }

--- a/custom_components/hpprinter/strings.json
+++ b/custom_components/hpprinter/strings.json
@@ -50,7 +50,7 @@
           "toner": "Toner",
           "tonercartridge": "Toner",
           "inktank": "Ink Tank",
-          "rechargeableToner": "Toner tank",
+          "rechargeabletoner": "Toner tank",
           "imagedrum": "Image Drum"
         }
       },

--- a/custom_components/hpprinter/strings.json
+++ b/custom_components/hpprinter/strings.json
@@ -49,7 +49,9 @@
           "printhead": "Printhead",
           "toner": "Toner",
           "tonercartridge": "Toner",
-          "inktank": "Ink Tank"
+          "inktank": "Ink Tank",
+          "rechargeabletoner": "Toner tank",
+          "imagedrum": "Image Drum"
         }
       },
       "estimated_pages_remaining": {

--- a/custom_components/hpprinter/strings.json
+++ b/custom_components/hpprinter/strings.json
@@ -50,7 +50,7 @@
           "toner": "Toner",
           "tonercartridge": "Toner",
           "inktank": "Ink Tank",
-          "rechargeabletoner": "Toner tank",
+          "rechargeableToner": "Toner tank",
           "imagedrum": "Image Drum"
         }
       },


### PR DESCRIPTION
These areused by HP Neverstop printers.

This fixes these two warnings in the HA logs:
* `Unsupported value of consumable_type_enum, expecting: ['ink', 'inkcartridge', 'printhead', 'toner', 'tonercartridge', 'inktank'], received: rechargeableToner`
* `Unsupported value of consumable_type_enum, expecting: ['ink', 'inkcartridge', 'printhead', 'toner', 'tonercartridge', 'inktank'], received: imageDrum`